### PR TITLE
Under node 0.10.x inflate does not have .destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ exports.parseStream = function(stream, callback) {
 
   function error(err) {
     stream.destroy()
-    inflate.destroy()
+    inflate.destroy && inflate.destroy()
     return callback(err)
   }
 
@@ -80,7 +80,7 @@ exports.parseStream = function(stream, callback) {
   })
 
   inflate.on("end", function() {
-    inflate.destroy()
+    inflate.destroy && inflate.destroy()
 
     if(p !== pngPixels.length)
       return error(new Error("Too little pixel data! (Corrupt PNG?)"))


### PR DESCRIPTION
This is just a change that I'm having to make to get it working.  Ideally, we could use streams2 and utilize `.pipe` instead.  Nice library btw! 

Edit: digging a bit deeper, I've noticed that I'm calling `parseStream` directly
